### PR TITLE
Use `netstandard2.0` and `net8.0` targets for VbaCompression library

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>1.0.0</VersionPrefix>
-    <TargetFrameworks>net462;net48;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <VersionPrefix>1.0.0</VersionPrefix>
     <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Kavod.Vba.Compression.Tests/Kavod.Vba.Compression.Tests.csproj
+++ b/src/Kavod.Vba.Compression.Tests/Kavod.Vba.Compression.Tests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFrameworks>net48;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Kavod.Vba.Compression/Extensions.cs
+++ b/src/Kavod.Vba.Compression/Extensions.cs
@@ -10,7 +10,7 @@ namespace Kavod.Vba.Compression
         [DebuggerStepThrough]
         internal static byte[] ToMcbsBytes(this string textToConvert, UInt16 codePage)
         {
-#if !NET48
+#if NET
             Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
 #endif
             return Encoding.GetEncoding(codePage).GetBytes(textToConvert);


### PR DESCRIPTION
Unit tests project must target actual .NET release so we use .NET Framework 4.8 instead of `netstandard2.0`

Implements issue #4