### PR TITLE
Remove the `System.Text.Encoding.CodePages` package reference

### DIFF
--- a/src/Kavod.Vba.Compression/Kavod.Vba.Compression.csproj
+++ b/src/Kavod.Vba.Compression/Kavod.Vba.Compression.csproj
@@ -6,10 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="8.0.0" />
-  </ItemGroup>
-
-  <ItemGroup>
     <None Include="README.md" Pack="true" PackagePath="\" />
     <None Include="Icon.png" Pack="true" PackagePath="\" />
   </ItemGroup>


### PR DESCRIPTION
It's included in the .NET 8 and newer runtimes. System will always use the latest available version.

Fixes issue #6