### PR TITLE
Refactor unit tests to TUnit framework

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,17 +38,16 @@ jobs:
       uses: actions/setup-dotnet@v5
       with:
         dotnet-version: |
-          8
           10
 
     - name: restore
       run: dotnet restore
 
     - name: build
-      run: dotnet build --no-restore
+      run: dotnet build --no-restore -c ${{ matrix.configuration }}
 
     - name: test
-      run: dotnet test --no-build --no-restore
+      run: dotnet test --no-build --no-restore -c ${{ matrix.configuration }}
       env:
         TestNetCoreOnly: ${{ contains(matrix.os, 'ubuntu') }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,20 +34,19 @@ jobs:
       uses: actions/setup-dotnet@v5
       with:
         dotnet-version: |
-          8
           10
 
     - name: restore
       run: dotnet restore
 
     - name: build
-      run: dotnet build --no-restore
+      run: dotnet build --no-restore -c Release
 
     - name: test
-      run: dotnet test --no-build --no-restore
+      run: dotnet test --no-build --no-restore -c Release
 
     - name: pack
-      run: dotnet pack --no-build --no-restore -o dist
+      run: dotnet pack --no-build --no-restore -c Release -o dist
 
     - name: publish artifact
       uses: actions/upload-artifact@v7

--- a/global.json
+++ b/global.json
@@ -1,0 +1,5 @@
+{
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
+  }
+}

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>3.0.1</VersionPrefix>
-    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <LangVersion>14.0</LangVersion>
   </PropertyGroup>
 

--- a/src/Kavod.Vba.Compression.Tests/CompressionExamples.cs
+++ b/src/Kavod.Vba.Compression.Tests/CompressionExamples.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Linq;
-using Xunit;
 
 namespace Kavod.Vba.Compression.Tests
 {
@@ -25,28 +24,28 @@ namespace Kavod.Vba.Compression.Tests
             _expectedCompressedBytes = Extensions.StringToByteArray(ExpectedCompressedOutput.Replace(" ", ""));
         }
 
-        [Fact]
-        public void InputValueAndDecompressedOutputAreSame()
+        [Test]
+        public async Task InputValueAndDecompressedOutputAreSame()
         {
-            Assert.True(_expectedDecompressedBytes.SequenceEqual(_compressionInputBytes));
+            await Assert.That(_expectedDecompressedBytes.SequenceEqual(_compressionInputBytes)).IsTrue();
         }
 
-        [Fact]
-        public void CompressionProducesExpectedOutput()
+        [Test]
+        public async Task CompressionProducesExpectedOutput()
         {
             var compressed = VbaCompression.Compress(_compressionInputBytes);
 
-            Assert.Equal(_expectedCompressedBytes.Length, compressed.Length);
-            Assert.True(_expectedCompressedBytes.SequenceEqual(compressed));
+            await Assert.That(compressed.Length).IsEqualTo(_expectedCompressedBytes.Length);
+            await Assert.That(_expectedCompressedBytes.SequenceEqual(compressed)).IsTrue();
         }
 
-        [Fact]
-        public void DecompressionProducesExpectedOutput()
+        [Test]
+        public async Task DecompressionProducesExpectedOutput()
         {
             var decompressed = VbaCompression.Decompress(_expectedCompressedBytes);
 
-            Assert.Equal(_expectedDecompressedBytes.Length, _compressionInputBytes.Length);
-            Assert.True(_expectedDecompressedBytes.SequenceEqual(_compressionInputBytes));
+            await Assert.That(_compressionInputBytes.Length).IsEqualTo(_expectedDecompressedBytes.Length);
+            await Assert.That(_expectedDecompressedBytes.SequenceEqual(_compressionInputBytes)).IsTrue();
         }
     }
 
@@ -73,25 +72,26 @@ namespace Kavod.Vba.Compression.Tests
             _expectedCompressedBytes = Extensions.StringToByteArray(ExpectedCompressedOutput.Replace(" ", ""));
         }
 
-        [Fact]
-        public void InputValueAndDecompressedOutputAreSame()
+        [Test]
+        public async Task InputValueAndDecompressedOutputAreSame()
         {
-            Assert.True(_expectedDecompressedBytes.SequenceEqual(_compressionInputBytes));
+            await Assert.That(_expectedDecompressedBytes.SequenceEqual(_compressionInputBytes)).IsTrue();
         }
 
-        [Fact(Skip = "Does not pass.")]
-        public void CompressionProducesExpectedOutput()
+        [Test]
+        [Skip("Does not pass.")]
+        public async Task CompressionProducesExpectedOutput()
         {
-            CompressionTestHelper.LowLevelCompressionComparison(_expectedDecompressedBytes, _expectedCompressedBytes);
+            await CompressionTestHelper.LowLevelCompressionComparison(_expectedDecompressedBytes, _expectedCompressedBytes);
         }
 
-        [Fact]
-        public void DecompressionProducesExpectedOutput()
+        [Test]
+        public async Task DecompressionProducesExpectedOutput()
         {
             var decompressed = VbaCompression.Decompress(_expectedCompressedBytes);
 
-            Assert.Equal(_expectedDecompressedBytes.Length, decompressed.Length);
-            Assert.True(_expectedDecompressedBytes.SequenceEqual(decompressed));
+            await Assert.That(decompressed.Length).IsEqualTo(_expectedDecompressedBytes.Length);
+            await Assert.That(_expectedDecompressedBytes.SequenceEqual(decompressed)).IsTrue();
         }
     }
 
@@ -117,28 +117,28 @@ namespace Kavod.Vba.Compression.Tests
             _expectedCompressedBytes = Extensions.StringToByteArray(ExpectedCompressedOutput.Replace(" ", ""));
         }
 
-        [Fact]
-        public void InputValueAndDecompressedOutputAreSame()
+        [Test]
+        public async Task InputValueAndDecompressedOutputAreSame()
         {
-            Assert.True(_expectedDecompressedBytes.SequenceEqual(_compressionInputBytes));
+            await Assert.That(_expectedDecompressedBytes.SequenceEqual(_compressionInputBytes)).IsTrue();
         }
 
-        [Fact]
-        public void CompressionProducesExpectedOutput()
+        [Test]
+        public async Task CompressionProducesExpectedOutput()
         {
             var compressed = VbaCompression.Compress(_compressionInputBytes);
 
-            Assert.Equal(_expectedCompressedBytes.Length, compressed.Length);
-            Assert.True(_expectedCompressedBytes.SequenceEqual(compressed));
+            await Assert.That(compressed.Length).IsEqualTo(_expectedCompressedBytes.Length);
+            await Assert.That(_expectedCompressedBytes.SequenceEqual(compressed)).IsTrue();
         }
 
-        [Fact]
-        public void DecompressionProducesExpectedOutput()
+        [Test]
+        public async Task DecompressionProducesExpectedOutput()
         {
             var decompressed = VbaCompression.Decompress(_expectedCompressedBytes);
 
-            Assert.Equal(_expectedDecompressedBytes.Length, _compressionInputBytes.Length);
-            Assert.True(_expectedDecompressedBytes.SequenceEqual(_compressionInputBytes));
+            await Assert.That(_compressionInputBytes.Length).IsEqualTo(_expectedDecompressedBytes.Length);
+            await Assert.That(_expectedDecompressedBytes.SequenceEqual(_compressionInputBytes)).IsTrue();
         }
     }
 }

--- a/src/Kavod.Vba.Compression.Tests/CompressionTestHelper.cs
+++ b/src/Kavod.Vba.Compression.Tests/CompressionTestHelper.cs
@@ -1,12 +1,11 @@
 using System.Collections.Generic;
 using System.Linq;
-using Xunit;
 
 namespace Kavod.Vba.Compression.Tests
 {
     public static class CompressionTestHelper
     {
-        public static void LowLevelCompressionComparison(byte[] decompressedBytes, byte[] expectedCompressedBytes)
+        public static async Task LowLevelCompressionComparison(byte[] decompressedBytes, byte[] expectedCompressedBytes)
         {
             var refCompressed = new CompressedContainer(expectedCompressedBytes);
             var decompressed = new DecompressedBuffer(decompressedBytes);
@@ -15,12 +14,11 @@ namespace Kavod.Vba.Compression.Tests
             var refTokens = GetTokensFromCompressedContainer(refCompressed).OfType<CopyToken>().ToList();
             var sutTokens = GetTokensFromCompressedContainer(sutCompressed).OfType<CopyToken>().ToList();
 
-            //Assert.Equal(refTokens.Count, sutTokens.Count);
             for (var i = 0; i < refTokens.Count; i++)
             {
                 var expected = refTokens[i];
                 var actual = sutTokens[i];
-                Assert.Equal(expected, actual);
+                await Assert.That(actual).IsEqualTo(expected);
             }
         }
 

--- a/src/Kavod.Vba.Compression.Tests/GlobalUsings.cs
+++ b/src/Kavod.Vba.Compression.Tests/GlobalUsings.cs
@@ -1,0 +1,4 @@
+global using System.Threading.Tasks;
+global using TUnit.Assertions;
+global using TUnit.Assertions.Extensions;
+global using TUnit.Core;

--- a/src/Kavod.Vba.Compression.Tests/Kavod.Vba.Compression.Tests.csproj
+++ b/src/Kavod.Vba.Compression.Tests/Kavod.Vba.Compression.Tests.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -20,12 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="TUnit" Version="1.45.29" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Kavod.Vba.Compression.Tests/LargeCompressionTests.cs
+++ b/src/Kavod.Vba.Compression.Tests/LargeCompressionTests.cs
@@ -1,33 +1,32 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using Xunit;
 
 namespace Kavod.Vba.Compression.Tests
 {
     public class LargeCompressionTests
     {
-        [Fact]
-        public void GivenLargeByteSequenceWithLowCompressibilityCompressionProducesContainerWithMultipleRawChunks()
+        [Test]
+        public async Task GivenLargeByteSequenceWithLowCompressibilityCompressionProducesContainerWithMultipleRawChunks()
         {
             var data = GetLargeByteSequenceWithLowCompressibility().ToArray();
 
             var container = new CompressedContainer(new DecompressedBuffer(data));
 
-            Assert.True(container.CompressedChunks.Count() > 1);
-            Assert.True(container.CompressedChunks.Count(c => c.Header.IsCompressed) <= 1);  // last chunk may be compressed
+            await Assert.That(container.CompressedChunks.Count()).IsGreaterThan(1);
+            await Assert.That(container.CompressedChunks.Count(c => c.Header.IsCompressed)).IsLessThanOrEqualTo(1);  // last chunk may be compressed
         }
 
-        [Fact]
-        public void GivenLargeByteSequenceWithLowCompressibilityCompressingAndDecompressionProducesSameInput()
+        [Test]
+        public async Task GivenLargeByteSequenceWithLowCompressibilityCompressingAndDecompressionProducesSameInput()
         {
             var data = GetLargeByteSequenceWithLowCompressibility().ToArray();
 
             var compressedData = VbaCompression.Compress(data);
             var convertedData = VbaCompression.Decompress(compressedData);
 
-            Assert.True(data != convertedData);
-            Assert.True(data.LongLength == convertedData.LongLength);
-            Assert.True(data.SequenceEqual(convertedData));
+            await Assert.That(ReferenceEquals(data, convertedData)).IsFalse();
+            await Assert.That(convertedData.LongLength).IsEqualTo(data.LongLength);
+            await Assert.That(data.SequenceEqual(convertedData)).IsTrue();
         }
 
         private IEnumerable<byte> GetLargeByteSequenceWithLowCompressibility()

--- a/src/Kavod.Vba.Compression.Tests/TestCompressedChunkHeader.cs
+++ b/src/Kavod.Vba.Compression.Tests/TestCompressedChunkHeader.cs
@@ -1,13 +1,12 @@
 ﻿using System;
 using System.Linq;
-using Xunit;
 
 namespace Kavod.Vba.Compression.Tests
 {
     public class TestCompressedChunkHeader
     {
-        [Fact]
-        public void DecodeEncodeHeader()
+        [Test]
+        public async Task DecodeEncodeHeader()
         {
             var data = BitConverter.ToUInt16(new byte[] {
             0x50,
@@ -15,7 +14,7 @@ namespace Kavod.Vba.Compression.Tests
             }, 0);
             var header = new CompressedChunkHeader(data);
 
-            Assert.True(BitConverter.GetBytes(data).SequenceEqual(header.SerializeData()));
+            await Assert.That(BitConverter.GetBytes(data).SequenceEqual(header.SerializeData())).IsTrue();
         }
     }
 }

--- a/src/Kavod.Vba.Compression.Tests/TestCompressedContainer.cs
+++ b/src/Kavod.Vba.Compression.Tests/TestCompressedContainer.cs
@@ -1,6 +1,5 @@
 ﻿using System.IO;
 using System.Linq;
-using Xunit;
 
 namespace Kavod.Vba.Compression.Tests
 {
@@ -15,67 +14,69 @@ namespace Kavod.Vba.Compression.Tests
             _validDecompressedDirStream = File.ReadAllBytes(@"Test Files/ValidDecompressedDirStream");
         }
 
-        [Fact]
-        public void CanCreateCompressedContainer()
+        [Test]
+        public async Task CanCreateCompressedContainer()
         {
             var container = new CompressedContainer(_validCompressedDirStream);
 
-            Assert.IsType<CompressedContainer>(container);
+            await Assert.That(container).IsTypeOf<CompressedContainer>();
         }
 
 
-        [Fact]
-        public void DecompressedDataSameAsMicrosoftImplementation()
+        [Test]
+        public async Task DecompressedDataSameAsMicrosoftImplementation()
         {
             var container = new CompressedContainer(_validCompressedDirStream);
             var buffer = new DecompressedBuffer(container);
 
-            Assert.True(buffer.Data.SequenceEqual(_validDecompressedDirStream));
+            await Assert.That(buffer.Data.SequenceEqual(_validDecompressedDirStream)).IsTrue();
         }
 
 
-        [Fact]
-        public void ParsedCompressedDataIsSameAsInput()
+        [Test]
+        public async Task ParsedCompressedDataIsSameAsInput()
         {
             var container = new CompressedContainer(_validCompressedDirStream);
 
-            Assert.True(container.SerializeData().SequenceEqual(_validCompressedDirStream));
+            await Assert.That(container.SerializeData().SequenceEqual(_validCompressedDirStream)).IsTrue();
         }
 
-        [Fact(Skip = "Does not pass.")]
-        public void CompressedDataSameAsMicrosoftImplementation()
+        [Test]
+        [Skip("Does not pass.")]
+        public async Task CompressedDataSameAsMicrosoftImplementation()
         {
             var buffer = new DecompressedBuffer(_validDecompressedDirStream);
             var container = new CompressedContainer(buffer);
 
-            Assert.True(container.SerializeData().SequenceEqual(_validCompressedDirStream));
+            await Assert.That(container.SerializeData().SequenceEqual(_validCompressedDirStream)).IsTrue();
         }
 
-        [Fact]
-        public void CompressDecompressDataAreEqual()
+        [Test]
+        public async Task CompressDecompressDataAreEqual()
         {
             var buffer = new DecompressedBuffer(_validDecompressedDirStream);
             var container = new CompressedContainer(buffer);
             var newBuffer = new DecompressedBuffer(container);
 
-            Assert.True(newBuffer.Data.SequenceEqual(_validDecompressedDirStream));
+            await Assert.That(newBuffer.Data.SequenceEqual(_validDecompressedDirStream)).IsTrue();
         }
 
-        [Fact]
-        public void GivenCompressedDataThatSerializingItReproducesSameData()
+        [Test]
+        public async Task GivenCompressedDataThatSerializingItReproducesSameData()
         {
             var refCompressed = new CompressedContainer(_validCompressedDirStream);
 
             var actual = refCompressed.SerializeData();
 
-            Assert.Equal(_validCompressedDirStream.Length, actual.Length);
-            Assert.Equal(_validCompressedDirStream, actual);
+            await Assert.That(actual.Length).IsEqualTo(_validCompressedDirStream.Length);
+            await Assert.That(actual.SequenceEqual(_validCompressedDirStream)).IsTrue();
         }
 
-        [Fact(Skip = "Does not pass.")]
-        public void TestDirStreamCompression()
+        [Test]
+        [Skip("Does not pass.")]
+        public async Task TestDirStreamCompression()
         {
-            CompressionTestHelper.LowLevelCompressionComparison(_validDecompressedDirStream, _validCompressedDirStream);
+            await CompressionTestHelper.LowLevelCompressionComparison(_validDecompressedDirStream, _validCompressedDirStream);
         }
     }
 }

--- a/src/Kavod.Vba.Compression.Tests/TestCopyToken.cs
+++ b/src/Kavod.Vba.Compression.Tests/TestCopyToken.cs
@@ -1,12 +1,11 @@
 ﻿using System;
-using Xunit;
 
 namespace Kavod.Vba.Compression.Tests
 {
     public class TestCopyToken
     {
-        [Fact]
-        public void GivenRangeOfPositionOffsetAndLengthPackingThenunPackingDataProducesTheOriginalParameters()
+        [Test]
+        public async Task GivenRangeOfPositionOffsetAndLengthPackingThenunPackingDataProducesTheOriginalParameters()
         {
             const int increment = 5;
 
@@ -22,8 +21,8 @@ namespace Kavod.Vba.Compression.Tests
 
                         CopyToken.UnPack(tokenData, position, out var actualOffset, out var actualLength);
 
-                        Assert.Equal(offset, actualOffset);
-                        Assert.Equal(length, actualLength);
+                        await Assert.That(actualOffset).IsEqualTo(offset);
+                        await Assert.That(actualLength).IsEqualTo(length);
                     }
                 }
             }
@@ -41,32 +40,32 @@ namespace Kavod.Vba.Compression.Tests
         //  513 - 1024      6           66              10
         //  1025 - 2048     5           34              11
         //  2049 - 4096     4           18              12
-        [Theory]
-        [InlineData(1, 12, 4098, 4)]
-        [InlineData(16, 12, 4098, 4)]
-        [InlineData(17, 11, 2050, 5)]
-        [InlineData(32, 11, 2050, 5)]
-        [InlineData(33, 10, 1026, 6)]
-        [InlineData(64, 10, 1026, 6)]
-        [InlineData(65, 9, 514, 7)]
-        [InlineData(128, 9, 514, 7)]
-        [InlineData(129, 8, 258, 8)]
-        [InlineData(256, 8, 258, 8)]
-        [InlineData(257, 7, 130, 9)]
-        [InlineData(512, 7, 130, 9)]
-        [InlineData(513, 6, 66, 10)]
-        [InlineData(1024, 6, 66, 10)]
-        [InlineData(1025, 5, 34, 11)]
-        [InlineData(2048, 5, 34, 11)]
-        [InlineData(2049, 4, 18, 12)]
-        [InlineData(4096, 4, 18, 12)]
-        public void TestTokenHelp(int position, ushort expectedLengthBitCount, ushort expectedMaxLength, ushort expectedOffsetBitCount)
+        [Test]
+        [Arguments(1, 12, 4098, 4)]
+        [Arguments(16, 12, 4098, 4)]
+        [Arguments(17, 11, 2050, 5)]
+        [Arguments(32, 11, 2050, 5)]
+        [Arguments(33, 10, 1026, 6)]
+        [Arguments(64, 10, 1026, 6)]
+        [Arguments(65, 9, 514, 7)]
+        [Arguments(128, 9, 514, 7)]
+        [Arguments(129, 8, 258, 8)]
+        [Arguments(256, 8, 258, 8)]
+        [Arguments(257, 7, 130, 9)]
+        [Arguments(512, 7, 130, 9)]
+        [Arguments(513, 6, 66, 10)]
+        [Arguments(1024, 6, 66, 10)]
+        [Arguments(1025, 5, 34, 11)]
+        [Arguments(2048, 5, 34, 11)]
+        [Arguments(2049, 4, 18, 12)]
+        [Arguments(4096, 4, 18, 12)]
+        public async Task TestTokenHelp(int position, int expectedLengthBitCount, int expectedMaxLength, int expectedOffsetBitCount)
         {
             var result = CopyToken.CopyTokenHelp(position);
 
-            Assert.Equal(expectedLengthBitCount, result.LengthBitCount);
-            Assert.Equal(expectedMaxLength, result.MaximumLength);
-            Assert.Equal(expectedOffsetBitCount, result.BitCount);
+            await Assert.That((int)result.LengthBitCount).IsEqualTo(expectedLengthBitCount);
+            await Assert.That((int)result.MaximumLength).IsEqualTo(expectedMaxLength);
+            await Assert.That((int)result.BitCount).IsEqualTo(expectedOffsetBitCount);
         }
     }
 }

--- a/src/Kavod.Vba.Compression.Tests/TestTokenSequence.cs
+++ b/src/Kavod.Vba.Compression.Tests/TestTokenSequence.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using Xunit;
 
 namespace Kavod.Vba.Compression.Tests
 {
@@ -7,15 +6,15 @@ namespace Kavod.Vba.Compression.Tests
     {
         const int TokenIndexToCheck = 3;
 
-        [Fact]
-        public void TestMatchMethod()
+        [Test]
+        public async Task TestMatchMethod()
         {
             var bytes = new byte[] { 1, 1, 1, 2, 1, 1, 1, 2, 1, 2 };
 
             Tokenizer.Match(bytes, 4, out var offset, out var length);
 
-            Assert.Equal(Convert.ToUInt16(4), offset);
-            Assert.Equal(Convert.ToUInt16(5), length);
+            await Assert.That(offset).IsEqualTo(Convert.ToUInt16(4));
+            await Assert.That(length).IsEqualTo(Convert.ToUInt16(5));
         }
     }
 }


### PR DESCRIPTION
TUnit improves the performance a lot:

```
dotnet test

Test run summary: Passed!
  total: 39
  failed: 0
  succeeded: 36
  skipped: 3
  duration: 1s 895ms
```


Former `xunit` tests:

```
dotnet test

[xUnit.net 00:00:02.31]   Finished:    Kavod.Vba.Compression.Tests
  Kavod.Vba.Compression.Tests test net10.0 succeeded (3.0s)
[xUnit.net 00:00:02.43]   Finished:    Kavod.Vba.Compression.Tests
  Kavod.Vba.Compression.Tests test net8.0 succeeded (3.2s)

Test summary: total: 78, failed: 0, succeeded: 72, skipped: 6, duration: 3.2s
Build succeeded in 4.4s
```